### PR TITLE
Add a GitHub Actions workflow for pull request builds.

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,81 @@
+on: pull_request
+name: Pull request
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - uses: actions/cache@v2
+      with:
+        path: ~/.npm
+        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-node-
+    - run: npm ci
+    - run: npm run lint
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - uses: actions/cache@v2
+      id: npm-cache
+      with:
+        path: ~/.npm
+        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-node-
+    - run: npm ci
+    - run: npm run test
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - uses: actions/cache@v2
+      with:
+        path: ~/.npm
+        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-node-
+    - run: npm ci
+    - run: npm run lint
+  docs:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - uses: actions/cache@v2
+      with:
+        path: ~/.npm
+        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-node-
+    - run: npm ci
+    - run: npm run build:doc
+    - run: git diff-files --name-only --exit-code


### PR DESCRIPTION
**⚠️ Note: this is a PR into `create-provider-hooks` and not `master/main`**

### TL;DR
Adds a [Github Actions](https://github.com/features/actions) CI [workflow](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions) for pull requests.

### Why?
This gives us confidence that new changes will cleanly integrate into the main branch, give us fast feedback mechanisms for linting, testing, compilation and ensures documentation is up-to-date. 

I went with Actions over, Travis, Circle CI etc due to its simplicity and first-class integration within the GitHub UI and its free for open-source projects.

### What?
The workflow is broken down into four self contained jobs which run concurrently on every push to a pull request: `lint`, `test`, `build`, and `docs`. 

Each job consists of the same boilerplate checkout, install node and load npm cache (which unfortunately can't be shared across jobs until this issue is fixed later this year: https://github.com/actions/runner/issues/438#issuecomment-658749461). All jobs run on a ubuntu image with node 12.x, however I left in a matrix for node versions if we want to test on more than one in the future.

I'm using `npm ci` instead of `npm install` which should lead to faster builds and it loads the cache for `~/.npm` from previous build based on the hash of the `package-lock.json` contents.

- `lint` runs `npm run lint` and will catch linting errors
- `test` runs `npm run test` and will catch test failures
- `build` runs `npm run build:dev` and will catch compilation errors. ***note:** this should be changed to `npm run build:prod` when it exists.*
- `docs` runs `npm run build:doc` and then validates whether the git tree is clean. This will ensure contributors always commit any updated documentation changes.
