### PR TITLE
Fix exported main and types fields in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "open-insights",
   "version": "0.1.0",
-  "main": "index.js",
-  "types": "types/index.d.ts",
+  "main": "dist/index.js",
+  "types": "dist/types/index.d.ts",
   "files": [
     "dist/**/*"
   ],


### PR DESCRIPTION
### TL;DR
Fixes the `main` and `types` properties in the `package.json` which was breaking reference projects and missed in #9. 