### PR TITLE
Refactor provider.getResourceUrl() to return a string instead of URL

### DIFF
--- a/src/@types/index.ts
+++ b/src/@types/index.ts
@@ -350,7 +350,7 @@ export interface Provider {
      * @param testConfig The test configuration, which usually specifies a base
      * URL from which the provider produces the runtime URL.
      */
-    getResourceUrl(testConfig: TestConfiguration): URL
+    getResourceUrl(testConfig: TestConfiguration): string
 
     /**
      * A hook enabling providers to specify a set of zero or more HTTP request

--- a/src/lib/fetch.test.ts
+++ b/src/lib/fetch.test.ts
@@ -110,7 +110,7 @@ describe("Fetch.execute", () => {
             provider.testSetUp.returns(
                 Promise.resolve(testCase.testSetUpResult),
             )
-            provider.getResourceUrl.returns(new URL(testCase.resourceUrl))
+            provider.getResourceUrl.returns(testCase.resourceUrl)
             const fetch = new Fetch(provider, testCase.fetchConfig)
 
             // Prepare the expected provider hook implementations
@@ -305,7 +305,7 @@ describe("Fetch.test", () => {
             // Setup stubs
             const provider = sinon.createStubInstance(UnitTestProvider)
             provider.getResourceRequestHeaders.returns({})
-            provider.getResourceUrl.returns(new URL(testCase.resourceUrl))
+            provider.getResourceUrl.returns(testCase.resourceUrl)
             if (!isFetchTestError(testCase.fetchTestResult)) {
                 provider.createFetchTestResult.resolves(
                     testCase.fetchTestResult,

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -68,7 +68,7 @@ export default class Fetch extends Test {
         return Promise.all<Response, ResourceTimingEntry>([
             this.fetchObject(),
             asyncGetEntry(
-                this.getResourceUrl().href,
+                this.getResourceUrl(),
                 (this._config as FetchConfiguration)
                     .performanceTimingObserverTimeout || defaultTimeout,
                 this._isValidEntryFunc,
@@ -88,7 +88,7 @@ export default class Fetch extends Test {
     /**
      * Calls {@link Provider.getResourceUrl} to generate the URL to be fetched.
      */
-    getResourceUrl(): URL {
+    getResourceUrl(): string {
         return this._provider.getResourceUrl(this._config)
     }
 
@@ -108,7 +108,7 @@ export default class Fetch extends Test {
         if (Object.keys(requestHeaders).length) {
             init.headers = requestHeaders
         }
-        const request = new Request(this.getResourceUrl().href, init)
+        const request = new Request(this.getResourceUrl(), init)
         return fetch(request)
     }
 }

--- a/src/lib/providerBase.ts
+++ b/src/lib/providerBase.ts
@@ -104,7 +104,7 @@ export default abstract class ProviderBase implements Provider {
     /**
      * See {@link Provider.getResourceUrl}.
      */
-    abstract getResourceUrl(testConfig: TestConfiguration): URL
+    abstract getResourceUrl(testConfig: TestConfiguration): string
 
     /**
      * See {@link Provider.getResourceRequestHeaders}.

--- a/src/testUtil/unitTestProvider.ts
+++ b/src/testUtil/unitTestProvider.ts
@@ -19,7 +19,7 @@ export default class UnitTestProvider extends ProviderBase {
     makeBeaconData(): BeaconData {
         throw new Error("Method not implemented.")
     }
-    getResourceUrl(): URL {
+    getResourceUrl(): string {
         throw new Error("Method not implemented.")
     }
     getResourceRequestHeaders(): Record<string, string> {


### PR DESCRIPTION
### TL;DR
Changes the return value of `provider.getResourceUrl()` to return a string instead of a `new URL()`. It seems we only ever call `url.href()` within business logic to get the full string representation back. 

I discovered this while implementation `open-insights-provider-fastly` and found it a pain to map the string returned in from the server `SessionConfig` to a `new URL()`. I'm also concerned about the overhead of having to polyfill URL for older UAs in our provider. 

That being said, this isn't a strongly held opinion so happy to close this PR if y'all would prefer the URL type as I do see the benefits of runtime type checking.