### PR TITLE
Avoid ESLint looking for parent configs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+    root: true,
     parser: "@typescript-eslint/parser",
     parserOptions: {
         ecmaVersion: 2020,


### PR DESCRIPTION
Allows development of the open-insights package within the context of a git submodule to a client project. Furthermore, I can't think of any use case where we would want ESLint using a config file up the directory structure from this repo.