### PR TITLE
providerBase.sessionConfig() shouldn't return undefined

### DIFF
--- a/src/lib/providerBase.ts
+++ b/src/lib/providerBase.ts
@@ -160,8 +160,9 @@ export default abstract class ProviderBase implements Provider {
     /**
      * See {@link Provider.sessionConfig}.
      */
-    get sessionConfig(): SessionConfig | undefined {
-        return this._sessionConfig
+    get sessionConfig(): SessionConfig {
+        /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
+        return this._sessionConfig!
     }
 
     /**


### PR DESCRIPTION
### TL;DR
Removes the potential `undefined` union return type from the `providerBase.sessionConfig()` signature using a [non-null assertion operator](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-0.html#non-null-assertion-operator). 

### Why?
This is another pain point I found while implementing the `open-insights-provider-fastly` provider. In many of the hooks an author may want to get some data from their `sessionConfig` object to determine what to do, however due to the potential `undefined` in the current signature, the compiler rightly doesn't allow access to the objects properties without a type guard first - such as:
```typescript
  getResourceUrl(testConfig: TaskData): string {
    if (this.sessionConfig === undefined) {
      return "";
    }
    return templateResource(testConfig.resource, this.sessionConfig);
  }
```
This resulted in most of my hooks starting with a type guard to assert whether sessionConfig was undef. One could argue that  this is TypeScript doing what it is designed to do and making me write safer code. However, in this instance, we always know that any call to `providerBase.sessionConfig()` is after the library initialisation and thus `setSessionConfig()` would have already been called and it's therefore safe to read the sessionConfig. I.e. this is an instance of we know better than the compiler.

---

As with other changes, I'm not strongly held to this so don't mind closing if y'all would prefer the type safety.