### PR TITLE
Introduce changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be listed here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - *NEXT*
+
+### Added
+
+- TODO

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,12 @@ All notable changes to this project will be listed here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.0] - *NEXT*
+## [next] - TBD
+
+After 0.1.0 has been tagged and a Github release made, start accumulating changes here.
+
+## [0.1.0] - TBD
 
 ### Added
 
-- TODO
+- Initial implementation of the Open Insights library.


### PR DESCRIPTION
Introduces a CHANGELOG.md. We should have a meeting to discuss how to manage it, along with CI/CD and other administrative chores, but I thought starting work on this file now might be practical.

My basic thought was for the topmost section (semver-TBD) to accumulate changes destined to become part of the "next" semver release. Each PR addressing an issue that users would want to know about should include a CHANGELOG.md update in this section.

When we decide it's time to tag a new release:

1. Someone updates the version number in package.json and CHANGELOG.md, grooms the CHANGELOG.md section for the new release, and makes a PR to merge those changes into `main`.
1. Once approved and merged, someone creates a tag from that commit and creates a [Release](https://github.blog/2013-07-02-release-your-software/). This probably involves harvesting details from CHANGELOG.md in order to produce the release notes.