### PR TITLE
Manually implement Promise.allSettled() within start()

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,22 @@
+on: push
+name: Lint
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - uses: actions/cache@v2
+      with:
+        path: ~/.npm
+        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-node-
+    - run: npm ci
+    - run: npm run lint-check-only

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,25 +1,6 @@
-on: [push, pull_request]
+on: pull_request
 name: Pull request
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [12.x]
-    steps:
-    - uses: actions/checkout@v2
-    - name: Install Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - uses: actions/cache@v2
-      with:
-        path: ~/.npm
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-node-
-    - run: npm ci
-    - run: npm run lint-check-only
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,4 +1,4 @@
-on: pull_request
+on: [push, pull_request]
 name: Pull request
 jobs:
   lint:
@@ -19,7 +19,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-node-
     - run: npm ci
-    - run: npm run lint
+    - run: npm run lint-check-only
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "build:doc": "rimraf doc && typedoc",
     "build:release": "rimraf dist && rollup -c",
     "lint": "tsc && eslint --fix src",
+    "lint-check-only": "tsc && eslint src",
     "test": "jest --coverage",
     "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",
     "prepublishOnly": "npm run build:release"

--- a/src/init.ts
+++ b/src/init.ts
@@ -48,12 +48,27 @@ function startLater(
  */
 function start(settings: ClientSettings): Promise<SessionResult> {
     const activeProviders = settings.providers.filter((p) => p.shouldRun())
-    return Promise.allSettled(
-        activeProviders.map((provider) => provider.fetchSessionConfig()),
+    // We can't use Promise.allSettled() below due to browser support.
+    // Therefore, we implement it manually via p.then().catch() to collect all
+    // results regardless of their resolution status. I.e. we polyfill.
+    return Promise.all(
+        activeProviders
+            .map((provider) => provider.fetchSessionConfig())
+            .map((p) =>
+                p
+                    .then((value) => ({
+                        status: "fulfilled",
+                        value,
+                    }))
+                    .catch((reason) => ({
+                        status: "rejected",
+                        reason,
+                    })),
+            ),
     ).then((settled) => {
         const executables: Executable[] = []
         settled.forEach((result, idx) => {
-            if (result.status === "fulfilled") {
+            if (result.status === "fulfilled" && "value" in result) {
                 const provider = activeProviders[idx]
                 provider.setSessionConfig(result.value)
                 executables.push(...provider.expandTasks())

--- a/src/init.ts
+++ b/src/init.ts
@@ -52,17 +52,19 @@ function start(settings: ClientSettings): Promise<SessionResult> {
     // Therefore, we implement it manually via p.then().catch() to collect all
     // results regardless of their resolution status. I.e. we polyfill.
     return Promise.all(
-        activeProviders.map((provider) => provider.fetchSessionConfig())
-        .map((p) =>
-            p.then((value) => ({
-                status: "fulfilled",
-                value
-            }))
-            .catch((reason) => ({
-                status: 'rejected',
-                reason
-            }))
-        )
+        activeProviders
+            .map((provider) => provider.fetchSessionConfig())
+            .map((p) =>
+                p
+                    .then((value) => ({
+                        status: "fulfilled",
+                        value,
+                    }))
+                    .catch((reason) => ({
+                        status: "rejected",
+                        reason,
+                    })),
+            ),
     ).then((settled) => {
         const executables: Executable[] = []
         settled.forEach((result, idx) => {


### PR DESCRIPTION
### TL;DR
This replaces our single use of [`Promise.allSettled()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled) with a manual implementation due to browser support and reports of runtime errors.

### Why?
When we originally implemented this, I queried the intersection of browsers that support this method against our other baseline support requirements and wrongly assumed we were safe. We have been observing runtime errors from Mobile Safari 12 and Safari 12 due to their lack of support. Therefore, I thought it would be easier to do the resolution manually.

### Notes
I attempted using a proper polyfill such as https://www.npmjs.com/package/promise.allsettled however the additional library bloat wasn't worth it compared to inlining the logic. But happy to be persuaded otherwise. I will also be canarying this change to get some real-world data.